### PR TITLE
Add Licence to manifest, fixes powercord detection.

### DIFF
--- a/powercord_manifest.json
+++ b/powercord_manifest.json
@@ -3,5 +3,6 @@
     "description":"Glowy Gradient - A red and black/transparent theme with some gradients, neon effects and square guild and profile pictures, as well as messenger-like text bubbles.",
     "version":"1.0.0",
     "author":"Shintensu",
-    "theme":"DiscordCustomCSS/GlowyGradient.css",
+    "license": "GPL-3.0",
+    "theme":"GlowyGradient.css",
 }


### PR DESCRIPTION
This fixes StyleManager giving error "Invalid Manifest" for "Invalid Licence" as the license string was missing. This was an internal error on my part.

This now also tells StyleManager to find the theme on the root of the cloned folder instead of a folder within itself as there is none.